### PR TITLE
Fix Github link: "flask-papertrail", not "flask_papertrail"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author=flask_papertrail.__author__,
     author_email=flask_papertrail.__email__,
     license='BSD',
-    url='https://github.com/cuonglm/flask_papertrail',
+    url='https://github.com/cuonglm/flask-papertrail',
     keywords=['flask', 'log'],
     install_requires=[
         'Flask'


### PR DESCRIPTION
Otherwise the link on [Pypi](https://pypi.org/project/Flask-PaperTrail/) doesn't work.